### PR TITLE
Testnet address checking

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -58,10 +58,10 @@ var Wallet = {
       rust.wallet_new_account(JSON.stringify({ wallet: wallet, account: account }))
     )
   },
-  generateAddresses: function (account, type, indices) {
+  generateAddresses: function (account, type, indices, protocolMagic) {
     return handleResultString(
       rust.wallet_generate_addresses(
-        JSON.stringify({ account: account, address_type: type, indices: indices }),
+        JSON.stringify({ account: account, address_type: type, indices: indices, protocol_magic: protocolMagic }),
         indices.length
       )
     )
@@ -73,7 +73,7 @@ var Wallet = {
   },
   spend: function (wallet, inputs, outputs, change_addr) {
     var input = {
-      wallet: wallet, inputs: inputs, 
+      wallet: wallet, inputs: inputs,
       outputs: outputs, change_addr: change_addr
     };
     var response = handleResultString(

--- a/lib/rncardano.js
+++ b/lib/rncardano.js
@@ -84,9 +84,9 @@ var Wallet = {
       return node.Wallet.newAccount(wallet, account);
     });
   },
-  generateAddresses: function (account, type, indices) {
+  generateAddresses: function (account, type, indices, protocolMagic) {
     return Promise.resolve().then(function() {
-      return node.Wallet.generateAddresses(account, type, indices);
+      return node.Wallet.generateAddresses(account, type, indices, protocolMagic);
     });
   },
   checkAddress: function (address) {

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["dylib"]
 neon-build = "0.2.0"
 
 [dependencies]
-wallet-wasm = { git = "https://github.com/ypopovych/js-cardano-wasm.git" }
-cardano = { git = "https://github.com/ypopovych/js-cardano-wasm.git" }
+wallet-wasm = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
+cardano = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
 neon = "0.2.0"
 
 [profile.release]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["dylib"]
 neon-build = "0.2.0"
 
 [dependencies]
-wallet-wasm = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
-cardano = { git = "https://github.com/rooooooooob/js-cardano-wasm.git", branch = "testnet-address-gen" }
+wallet-wasm = { git = "https://github.com/input-output-hk/js-cardano-wasm.git" }
+cardano = { git = "https://github.com/input-output-hk/js-cardano-wasm.git" }
 neon = "0.2.0"
 
 [profile.release]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cardano-wallet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Node.js bindings to the rust-cardano",
   "main": "lib/index.js",
   "author": "Crossroad Labs <info@crossroad.io>",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,56 +3,56 @@ import * as rncardano from './rncardano';
 export namespace HdWallet {
   export type XPrv = Buffer;
   export type XPub = Buffer;
-  
+
   // Generate an eXtended private key from the given entropy and the given password.
   export function fromEnhancedEntropy(entropy: Buffer, password: Buffer): XPrv;
-  
+
   // Create a private key from the given seed.
   export function fromSeed(seed: Buffer): XPrv;
-  
+
   // Get a public key for the private one.
   export function toPublic(xprv: XPrv): XPub;
-  
+
   // Create a derived private key with an index.
   export function derivePrivate(xprv: XPrv, index: number): XPrv;
-  
+
   // Create a derived public key with an index.
   export function derivePublic(xpub: XPub, index: number): XPub;
-  
+
   // Sign the given message with the private key.
   export function sign(xprv: XPrv, msg: Buffer): Buffer;
 }
-  
+
 export namespace Wallet {
   export type TransactionObj = {
     cbor_encoded_tx: Buffer;
     change_used: boolean;
     fee: string;
   };
-  
+
   // Create a wallet object from the given seed.
   export function fromMasterKey(xprv: HdWallet.XPrv): rncardano.Wallet.WalletObj;
-  
+
   // Create a daedalus wallet object from the given seed.
   export function fromDaedalusMnemonic(mnemonics: string): rncardano.Wallet.DaedalusWalletObj;
-  
+
   // Create an account, for public key derivation (using bip44 model).
   export function newAccount(wallet: rncardano.Wallet.WalletObj, account: number): rncardano.Wallet.AccountObj;
-  
+
   // Generate addresses for the given wallet.
   export function generateAddresses(
-    account: rncardano.Wallet.AccountObj, type: rncardano.Wallet.AddressType, indices: Array<number>
+    account: rncardano.Wallet.AccountObj, type: rncardano.Wallet.AddressType, indices: Array<number>, protocolMagic: number
   ): Array<rncardano.Wallet.Address>;
 
   // Check if the given base58 string is a valid Cardano Extended Address.
   export function checkAddress(address: rncardano.Wallet.Address): boolean;
-  
+
   // Generate a ready to send, signed, transaction.
   export function spend(
     wallet: rncardano.Wallet.WalletObj, inputs: Array<rncardano.Wallet.SpendInputObj>,
     outputs: Array<rncardano.Wallet.OutputObj>, change_addr: rncardano.Wallet.Address
   ): TransactionObj;
-  
+
   // Move all UTxO to a single address.
   export function move(
     wallet: rncardano.Wallet.DaedalusWalletObj,
@@ -60,26 +60,26 @@ export namespace Wallet {
     output: rncardano.Wallet.Address
   ): TransactionObj;
 }
-  
-export namespace RandomAddressChecker {  
+
+export namespace RandomAddressChecker {
   // Create a random address checker, this will allow validating.
   export function newChecker(xprv: HdWallet.XPrv): rncardano.RandomAddressChecker.AddressCheckerObj;
-  
+
   // Create a random address checker from daedalus mnemonics.
   export function newCheckerFromMnemonics(mnemonics: string): rncardano.RandomAddressChecker.AddressCheckerObj;
-  
+
   // Check if the given addresses are valid.
   export function checkAddresses(
     checker: rncardano.RandomAddressChecker.AddressCheckerObj, addresses: Array<rncardano.Wallet.Address>
   ): Array<{ address: rncardano.Wallet.Address, addressing: [number, number] }>;
 }
-  
+
 export namespace PasswordProtect {
   // Encrypt the given data with the password, salt and nonce.
   export function encryptWithPassword(
     password: Buffer, salt: Buffer, nonce: Buffer, data: Buffer
   ): Buffer;
-  
+
   // Decrypt the given data with the password.
   export function decryptWithPassword(password: Buffer, data: Buffer): Buffer;
 }


### PR DESCRIPTION
As tests of `yoroi-mobile` use this module instead of `react-native-cardano`, we needed to update this module as well to support testnet address generation and checking. The previous version was using an ancient version of `rust-cardano` which did not support testnet address verification either.

The API should remain consistent as the protocol magic is optional, and when not passed in, while stored in the JSON passed to `js-cardano-wasm`, will be considered as `None` and thus default to mainnet addresses.